### PR TITLE
MAINT: Simplify Contributing Guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,36 +1,18 @@
-# Contribution Guide
-Welcome to DSG's Machine Learning Interview Questions contribution guide. We thank you for investing your time in contributing to our project! 
+# Contribution Guide 
 
-In this guide you will get an overview of the contribution workflow from opening an issue, creating a PR, reviewing, and merging the PR.
-
-## New contributer guide
-To get an overview of the project, read the README. Here are some resources to help you get started with open source contributions:
-
-- [Finding ways to contribute to open source on GitHub](https://docs.github.com/en/get-started/exploring-projects-on-github/finding-ways-to-contribute-to-open-source-on-github)
-- [Set up Git](https://docs.github.com/en/get-started/quickstart/set-up-git)
-- [GitHub flow](https://docs.github.com/en/get-started/quickstart/github-flow)
-- [Collaborating with pull requests](https://docs.github.com/en/github/collaborating-with-pull-requests)
+An overview of the contribution workflow from opening an issue, creating a PR, reviewing, and merging the PR.
 
 ## Getting Started
-We store all of the questions in ```.yaml``` files. For more information about ```.yaml``` files, you can go through these resources:
+All the questions are stored in ```.yaml``` files. For more information about ```.yaml``` files, please visit:
 
 - [The official YAML website](https://yaml.org/)
 - [YAML Syntax](https://docs.ansible.com/ansible/latest/reference_appendices/YAMLSyntax.html)
-
-### Issues
-
-#### Create a new Issue
-If you spot a problem in this repository, or need to request a new tag, or a new key, [search if an issue already exists](https://docs.github.com/en/github/searching-for-information-on-github/searching-on-github/searching-issues-and-pull-requests#search-by-the-title-body-or-comments). If a related issue doesn't exist, you can open a new issue using a relevant [issue form](https://github.com/dsgiitr/ML-InterviewQs/issues/new/choose).
-
-#### Solve an Issue
-
-Scan through our [existing issues](https://github.com/dsgiitr/ML-InterviewQs/issues) to find one that interests you. You can narrow down the search using ```labels``` as filters. See [Labels](https://github.com/github/docs/blob/main/contributing/how-to-use-labels.md) for more information. As a general rule, we don’t assign issues to anyone. If you find an issue to work on, you are welcome to open a PR with a fix.
 
 ### Add questions
 
 #### Segregation
 
-We have divided all the questions into five broad categories: 
+Questions are divided into five broad categories: 
 
 - [Machine Learning](https://github.com/dsgiitr/ML-InterviewQs/questions/ml.yml)
 - [Deep Learning](https://github.com/dsgiitr/ML-InterviewQs/questions/dl.yml)
@@ -57,19 +39,31 @@ Each question is stored in a key-value format. There are a fixed set of keys, so
 
 To request the addition of a new key you can [create an issue](#Create-a-new-Issue).
 
+### Issues
+
+#### Create a new Issue
+If you spot a problem in this repository, or need to request a new tag, or a new key, [search if an issue already exists](https://docs.github.com/en/github/searching-for-information-on-github/searching-on-github/searching-issues-and-pull-requests#search-by-the-title-body-or-comments). If a related issue doesn't exist, you can open a new issue using a relevant [issue form](https://github.com/dsgiitr/ML-InterviewQs/issues/new/choose).
+
+#### Solve an Issue
+
+Scan through our [existing issues](https://github.com/dsgiitr/ML-InterviewQs/issues) to find one that interests you. You can narrow down the search using ```labels``` as filters. See [Labels](https://github.com/github/docs/blob/main/contributing/how-to-use-labels.md) for more information.
+
 #### Style guide
 We follow standard effective yaml guidelines. You can refer to [this guide](https://developers.home-assistant.io/docs/documenting/yaml-style-guide/) for more information.
-
-### Pull Request
-When you're finished with the changes, [create a pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request), also known as a PR. To know more about pull requests, see [About pull requests](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests).
 
 Keep these in mind while creating a pull request:
 
 - Don't forget to [link PR to issue](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) if you are solving one.
-- Enable the checkbox to [allow maintainer edits](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) so the branch can be updated for a merge. Once you submit your PR, a Docs team member will review your proposal. We may ask questions or request for additional information.
-- We may ask for changes to be made before a PR can be merged, either using [suggested changes](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/incorporating-feedback-in-your-pull-request) or pull request comments. You can apply suggested changes directly through the UI. You can make any other changes in your fork, then commit them to your branch.
-- As you update your PR and apply changes, mark each conversation as [resolved](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/commenting-on-a-pull-request#resolving-conversations).
-- If you run into any merge issues, checkout this [git tutorial](https://lab.github.com/githubtraining/managing-merge-conflicts) to help you resolve merge conflicts and other issues.
+- We may ask for changes to be made before a PR can be merged, either using [suggested changes](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/incorporating-feedback-in-your-pull-request) or pull request comments.
 
-### Your PR is merged!
-Congratulations :tada::tada: Team DSG thanks you :sparkles:
+
+## First time contributor?
+
+If you are new to contributing to open source, [this guide](https://opensource.guide/how-to-contribute/) helps explain why, what, and how to get involved. Here are some resources to help you get started with open source contributions:
+
+- [Finding ways to contribute to open source on GitHub](https://docs.github.com/en/get-started/exploring-projects-on-github/finding-ways-to-contribute-to-open-source-on-github)
+- [Set up Git](https://docs.github.com/en/get-started/quickstart/set-up-git)
+- [GitHub flow](https://docs.github.com/en/get-started/quickstart/github-flow)
+- [Collaborating with pull requests](https://docs.github.com/en/github/collaborating-with-pull-requests)
+
+We thank you for investing your time in contributing to this project!

--- a/README.md
+++ b/README.md
@@ -5,7 +5,5 @@ This repository aims to develop and compile a list of questions focussed on mach
 
 ## Call for Contributions
 
-We welcome community contributions, feel free to add your own question and solution to improve the question bank. Adding new questions isn't the only way to contribute, small improvements or fixes in the questions/solutions existing already are always appreciated. You can also help review pull requests, triage issues and suggest more features. Have a look at our [Contribution Guide](./CONTRIBUTING.md) for more details.
-
-If you’re unsure where to start, reach out at dsg@iitr.ac.in! You may also ask on GitHub, by opening a new issue or leaving a comment on a relevant issue that is already open.
+We welcome community contributions, feel free to add your own question and solution to improve the question bank. Adding new questions isn't the only way to contribute, small improvements or fixes in the questions/solutions existing already are always appreciated. You can also help review pull requests, triage issues and suggest more features. If you’re unsure where to start, have a look at our [Contribution Guide](./CONTRIBUTING.md) for more details or reach out at dsg@iitr.ac.in.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,11 @@
 # Machine Learning Interview Questions
-We at Data Science Group, IIT-R aim to develop a list of questions that have been asked in interviews for various data science roles, or can help a person prepare for the same. This has been a highly sought-after resource and we believe that it will help budding data scientists not only at IIT Roorkee, but all over the world:sparkles: 
 
-This repository contains a question bank to help prepare you for ML Interviews. Please contribute if you have some quetions in mind. To know more about contributing, see the [Contribution Guide](./CONTRIBUTING.md).
+This repository aims to develop and compile a list of questions focussed on machine learning interviews for various data science roles, to help prepare candidates for the same. Each question and its solution is critically reviewed and is structured with metadata tags to help sort and identify questions based on topics, difficuty etc.
+
+
+## Call for Contributions
+
+We welcome community contributions, feel free to add your own question and solution to improve the question bank. Adding new questions isn't the only way to contribute, small improvements or fixes in the questions/solutions existing already are always appreciated. You can also help review pull requests, triage issues and suggest more features. Have a look at our [Contribution Guide](./CONTRIBUTING.md) for more details.
+
+If you’re unsure where to start, reach out at dsg@iitr.ac.in! You may also ask on GitHub, by opening a new issue or leaving a comment on a relevant issue that is already open.
+


### PR DESCRIPTION
Removing some very general info and restructuring contribution guidelines. Let's make this more specific to the project going ahead instead of describing generic open-source rules (linking other pages is enough for that, already done at the end). More generic less important info has been moved towards the end.

> Enable the checkbox to [allow maintainer edits]

This is not mandatory (btw it is automatically checked).