### PR TITLE
ENH: Add support for images

### DIFF
--- a/images/README.md
+++ b/images/README.md
@@ -1,0 +1,2 @@
+# Images
+Add your images in this directory. 

--- a/images/README.md
+++ b/images/README.md
@@ -1,2 +1,0 @@
-# Images
-Add your images in this directory. 

--- a/questions/assets/README.md
+++ b/questions/assets/README.md
@@ -1,0 +1,2 @@
+# Images
+Add your files relevant to the question (images, videos, GIFs) in this directory. 

--- a/tags.md
+++ b/tags.md
@@ -50,4 +50,4 @@ Currently, there is a standard list of tags to be used, in order to avoid duplic
 - rnn
 - backprop
 
-To request the addition of a new tag, [create an issue](https://github.com/dsgiitr/ML-InterviewQs/CONTRIBUTING.md/#Create-a-new-Issue).
+To request the addition of a new tag, [create an issue](https://github.com/dsgiitr/ML-InterviewQs/blob/main/CONTRIBUTING.md#create-a-new-issue).


### PR DESCRIPTION
Adding a directory for contributors to add images as required by the `q_img` and `sol_img` tags. Also, fixing a broken link in ./tags.md.